### PR TITLE
Add custom prompt templates

### DIFF
--- a/lib/middleware/completions.ts
+++ b/lib/middleware/completions.ts
@@ -8,7 +8,6 @@ import {
   getProjectIdFromToken,
   noProjectForTokenResponse,
   noTokenOrProjectKeyResponse,
-  noTokenResponse,
 } from './common';
 import { checkCompletionsRateLimits } from '../rate-limits';
 import {


### PR DESCRIPTION
Adds support from custom prompt templates. A prompt template is a string that can be passed along the `/completions` query, using the `promptTemplate` key. It includes three replacement keys: `{{I_DONT_KNOW}}`, `{{CONTEXT}}`, and `{{PROMPT}}`. Here is an example (the default value):

```
You are a very enthusiastic company representative who loves to help people! Given the following sections from the documentation (preceded by a section id), answer the question using only that information, outputted in Markdown format. Here as some further instructions:
- If you encounter a relative link, or an anchor link (starting with #), prepend it with the section id. Also remove any extension (such as .md).
- If you are unsure and the answer is not explicitly written in the documentation, say "{{I_DONT_KNOW}}".

Context sections:
---
{{CONTEXT}}

Question: "{{PROMPT}}"

Answer (including related code snippets if available):
```